### PR TITLE
Fixed of m_lastDamageAmount  recording during armor calculation

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -1153,9 +1153,6 @@ BOOL EXT_FUNC CBasePlayer::__API_HOOK(TakeDamage)(entvars_t *pevInflictor, entva
 		}
 	}
 
-	// keep track of amount of damage last sustained
-	m_lastDamageAmount = flDamage;
-
 	// Armor
 	// armor doesn't protect against fall or drown damage!
 	if (pev->armorvalue != 0.0f && !(bitsDamageType & (DMG_DROWN | DMG_FALL)) && IsArmored(m_LastHitGroup))
@@ -1194,7 +1191,10 @@ BOOL EXT_FUNC CBasePlayer::__API_HOOK(TakeDamage)(entvars_t *pevInflictor, entva
 	{
 		Pain(m_LastHitGroup, false);
 	}
-
+	
+	// keep track of amount of damage last sustained
+	m_lastDamageAmount = flDamage;
+	
 	LogAttack(pAttack, this, bTeamAttack, flDamage, armorHit, pev->health - flDamage, pev->armorvalue, GetWeaponName(pevInflictor, pevAttacker));
 
 	// this cast to INT is critical!!! If a player ends up with 0.5 health, the engine will get that


### PR DESCRIPTION
This fix addresses an issue with the inaccurate recording of the last damage (m_lastDamageAmount) due to incorrect sequencing of operations in the code. In the original code, damage was recorded before it was adjusted based on armor, potentially resulting in the storage of incorrect data. This bug could affect precise damage calculations and gameplay analysis, particularly when tracking and assessing damage over time.